### PR TITLE
Provide Platform.sh configuration files.

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -1,0 +1,56 @@
+# This file describes an application. You can have multiple applications
+# in the same project.
+
+# The name of this app. Must be unique within a project.
+name: php
+
+# The runtime the application uses.
+type: "php:5.6"
+
+# Configuration of the build of this application.
+build:
+    flavor: composer
+
+# The build-time dependencies of the app.
+dependencies:
+    php:
+        "drush/drush": "dev-master"
+
+# The relationships of the application with services or other applications.
+# The left-hand side is the name of the relationship as it will be exposed
+# to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
+# side is in the form `<service name>:<endpoint name>`.
+relationships:
+    database: "mysql:mysql"
+#    solr: "solr:solr"
+#    redis: "redis:redis"
+
+# The configuration of app when it is exposed to the web.
+web:
+    # The public directory of the app, relative to its root.
+    document_root: "/web"
+    # The front-controller script to send non-static requests to.
+    passthru: "/index.php"
+
+# The size of the persistent disk of the application (in MB).
+disk: 2048
+
+# The mounts that will be performed when the package is deployed.
+mounts:
+    "/web/sites/default/files": "shared:files/files"
+    "/tmp": "shared:files/tmp"
+    "/config": "shared:files/config"
+    "/private": "shared:files/private"
+
+# The hooks executed at various points in the lifecycle of the application.
+hooks:
+    # We run deploy hook after your application has been deployed and started.
+    deploy: |
+      cd web
+      drush -y updatedb
+
+# The configuration of scheduled execution.
+crons:
+    drupal:
+        spec: "*/20 * * * *"
+        cmd: "cd web ; drush core-cron"

--- a/.platform/routes.yaml
+++ b/.platform/routes.yaml
@@ -1,0 +1,12 @@
+# The routes of the project.
+#
+# Each route describes how an incoming URL is going
+# to be processed by Platform.sh.
+
+"http://{default}/":
+    type: upstream
+    upstream: "php:php"
+
+"http://www.{default}/":
+    type: redirect
+    to: "http://{default}/"

--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -1,0 +1,15 @@
+# The services of the project.
+#
+# Each service listed will be deployed
+# to power your Platform.sh project.
+
+mysql:
+    type: mysql
+    disk: 2048
+#
+#redis:
+#    type: redis
+#
+#solr:
+#    type: solr
+#    disk: 1024

--- a/web/sites/default/services.yml
+++ b/web/sites/default/services.yml
@@ -1,0 +1,144 @@
+parameters:
+  session.storage.options:
+    # Default ini options for sessions.
+    #
+    # Some distributions of Linux (most notably Debian) ship their PHP
+    # installations with garbage collection (gc) disabled. Since Drupal depends
+    # on PHP's garbage collection for clearing sessions, ensure that garbage
+    # collection occurs by using the most common settings.
+    # @default 1
+    gc_probability: 1
+    # @default 100
+    gc_divisor: 100
+    #
+    # Set session lifetime (in seconds), i.e. the time from the user's last
+    # visit to the active session may be deleted by the session garbage
+    # collector. When a session is deleted, authenticated users are logged out,
+    # and the contents of the user's $_SESSION variable is discarded.
+    # @default 200000
+    gc_maxlifetime: 200000
+    #
+    # Set session cookie lifetime (in seconds), i.e. the time from the session
+    # is created to the cookie expires, i.e. when the browser is expected to
+    # discard the cookie. The value 0 means "until the browser is closed".
+    # @default 2000000
+    cookie_lifetime: 2000000
+    #
+    # Drupal automatically generates a unique session cookie name based on the
+    # full domain name used to access the site. This mechanism is sufficient
+    # for most use-cases, including multi-site deployments. However, if it is
+    # desired that a session can be reused across different subdomains, the
+    # cookie domain needs to be set to the shared base domain. Doing so assures
+    # that users remain logged in as they cross between various subdomains.
+    # To maximize compatibility and normalize the behavior across user agents,
+    # the cookie domain should start with a dot.
+    #
+    # @default none
+    # cookie_domain: '.example.com'
+    #
+  twig.config:
+    # Twig debugging:
+    #
+    # When debugging is enabled:
+    # - The markup of each Twig template is surrounded by HTML comments that
+    #   contain theming information, such as template file name suggestions.
+    # - Note that this debugging markup will cause automated tests that directly
+    #   check rendered HTML to fail. When running automated tests, 'debug'
+    #   should be set to FALSE.
+    # - The dump() function can be used in Twig templates to output information
+    #   about template variables.
+    # - Twig templates are automatically recompiled whenever the source code
+    #   changes (see auto_reload below).
+    #
+    # For more information about debugging Twig templates, see
+    # https://www.drupal.org/node/1906392.
+    #
+    # Not recommended in production environments
+    # @default false
+    debug: false
+    # Twig auto-reload:
+    #
+    # Automatically recompile Twig templates whenever the source code changes.
+    # If you don't provide a value for auto_reload, it will be determined
+    # based on the value of debug.
+    #
+    # Not recommended in production environments
+    # @default null
+    auto_reload: null
+    # Twig cache:
+    #
+    # By default, Twig templates will be compiled and stored in the filesystem
+    # to increase performance. Disabling the Twig cache will recompile the
+    # templates from source each time they are used. In most cases the
+    # auto_reload setting above should be enabled rather than disabling the
+    # Twig cache.
+    #
+    # Not recommended in production environments
+    # @default true
+    cache: true
+  renderer.config:
+    # Renderer required cache contexts:
+    #
+    # The Renderer will automatically associate these cache contexts with every
+    # render array, hence varying every render array by these cache contexts.
+    #
+    # @default ['languages:language_interface', 'theme', 'user.permissions']
+    required_cache_contexts: ['languages:language_interface', 'theme', 'user.permissions']
+    # Renderer automatic placeholdering conditions:
+    #
+    # Drupal allows portions of the page to be automatically deferred when
+    # rendering to improve cache performance. That is especially helpful for
+    # cache contexts that vary widely, such as the active user. On some sites
+    # those may be different, however, such as sites with only a handful of
+    # users. If you know what the high-cardinality cache contexts are for your
+    # site, specify those here. If you're not sure, the defaults are fairly safe
+    # in general.
+    #
+    # For more information about rendering optimizations see
+    # https://www.drupal.org/developing/api/8/render/arrays/cacheability#optimizing
+    auto_placeholder_conditions:
+      # Max-age at or below which caching is not considered worthwhile.
+      #
+      # Disable by setting to -1.
+      #
+      # @default 0
+      max-age: 0
+      # Cache contexts with a high cardinality.
+      #
+      # Disable by setting to [].
+      #
+      # @default ['session', 'user']
+      contexts: ['session', 'user']
+      # Tags with a high invalidation frequency.
+      #
+      # Disable by setting to [].
+      #
+      # @default []
+      tags: []
+  factory.keyvalue:
+    {}
+    # Default key/value storage service to use.
+    # @default keyvalue.database
+    # default: keyvalue.database
+    # Collection-specific overrides.
+    # state: keyvalue.database
+  factory.keyvalue.expirable:
+    {}
+    # Default key/value expirable storage service to use.
+    # @default keyvalue.database.expirable
+    # default: keyvalue.database.expirable
+  # Allowed protocols for URL generation.
+  filter_protocols:
+    - http
+    - https
+    - ftp
+    - news
+    - nntp
+    - tel
+    - telnet
+    - mailto
+    - irc
+    - ssh
+    - sftp
+    - webcal
+    - rtsp

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * @file
+ * Platform.sh example settings.php file for Drupal 8.
+ */
+// Install with the 'standard' profile for this example.
+$settings['install_profile'] = 'standard';
+// You should modify the hash_salt so that it is specific to your application.
+$settings['hash_salt'] = '4946c1912834b8477cc70af309a2c30dcec24c2103c724ff30bf13b4c10efd82';
+/**
+ * Default Drupal 8 settings.
+ *
+ * These are already explained with detailed comments in Drupal's
+ * default.settings.php file.
+ *
+ * See https://api.drupal.org/api/drupal/sites!default!default.settings.php/8
+ */
+$databases = array();
+$config_directories = array();
+$settings['update_free_access'] = FALSE;
+$settings['container_yamls'][] = __DIR__ . '/services.yml';
+// Override paths for config files in Platform.sh.
+// Define a config sync directory outside the document root.
+if (isset($_ENV['PLATFORM_APP_DIR'])) {
+  $config_directories[CONFIG_SYNC_DIRECTORY] = $_ENV['PLATFORM_APP_DIR'] . '/config/sync';
+}
+// Set trusted hosts based on real Platform.sh routes.
+if (isset($_ENV['PLATFORM_ROUTES'])) {
+  $routes = json_decode(base64_decode($_ENV['PLATFORM_ROUTES']), TRUE);
+  $settings['trusted_host_patterns'] = array();
+  foreach ($routes as $url => $route) {
+    $host = parse_url($url, PHP_URL_HOST);
+    if ($host !== FALSE && $route['type'] == 'upstream' && $route['upstream'] == $_ENV['PLATFORM_APPLICATION_NAME']) {
+      $settings['trusted_host_patterns'][] = '^' . preg_quote($host) . '$';
+    }
+  }
+  $settings['trusted_host_patterns'] = array_unique($settings['trusted_host_patterns']);
+}
+// Because we're using the Composer toolstack, we replicate the necessary local
+// settings file for Drupal here.
+if (getenv("PLATFORM_RELATIONSHIPS")) {
+  // Configure relationships.
+  $relationships = json_decode(base64_decode($_ENV['PLATFORM_RELATIONSHIPS']), TRUE);
+  if (empty($databases['default']['default'])) {
+    foreach ($relationships['database'] as $endpoint) {
+      $database = array(
+        'driver' => $endpoint['scheme'],
+        'database' => $endpoint['path'],
+        'username' => $endpoint['username'],
+        'password' => $endpoint['password'],
+        'host' => $endpoint['host'],
+      );
+      if (!empty($endpoint['query']['compression'])) {
+        $database['pdo'][PDO::MYSQL_ATTR_COMPRESS] = TRUE;
+      }
+      if (!empty($endpoint['query']['is_master'])) {
+        $databases['default']['default'] = $database;
+      }
+      else {
+        $databases['default']['slave'][] = $database;
+      }
+    }
+  }
+  $routes = json_decode(base64_decode($_ENV['PLATFORM_ROUTES']), TRUE);
+  if (!isset($conf['file_private_path'])) {
+    if(!$application_home = getenv('PLATFORM_APP_DIR')) {
+      $application_home = '/app';
+    }
+    $conf['file_private_path'] = $application_home . '/private';
+    $conf['file_temporary_path'] = $application_home . '/tmp';
+  }
+  $variables = json_decode(base64_decode($_ENV['PLATFORM_VARIABLES']), TRUE);
+  $prefix_len = strlen('drupal:');
+  foreach ($variables as $name => $value) {
+    if (substr($name, 0, $prefix_len) == 'drupal:') {
+      $conf[substr($name, $prefix_len)] = $value;
+    }
+  }
+  // Default PHP settings.
+  ini_set('session.gc_probability', 1);
+  ini_set('session.gc_divisor', 100);
+  ini_set('session.gc_maxlifetime', 200000);
+  ini_set('session.cookie_lifetime', 2000000);
+  ini_set('pcre.backtrack_limit', 200000);
+  ini_set('pcre.recursion_limit', 200000);
+}
+// Force Drupal not to check for HTTP connectivity until we fixed the self test.
+$conf['drupal_http_request_fails'] = FALSE;
+// Local settings. These allow local development environments to use their own
+// database connections rather than the Platform-only settings above.
+if (file_exists(__DIR__ . '/settings.local.php')) {
+  include __DIR__ . '/settings.local.php';
+}

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -3,10 +3,12 @@
  * @file
  * Platform.sh example settings.php file for Drupal 8.
  */
+
 // Install with the 'standard' profile for this example.
-$settings['install_profile'] = 'standard';
+$settings['install_profile'] = 'commerce_base';
 // You should modify the hash_salt so that it is specific to your application.
 $settings['hash_salt'] = '4946c1912834b8477cc70af309a2c30dcec24c2103c724ff30bf13b4c10efd82';
+
 /**
  * Default Drupal 8 settings.
  *
@@ -19,11 +21,13 @@ $databases = array();
 $config_directories = array();
 $settings['update_free_access'] = FALSE;
 $settings['container_yamls'][] = __DIR__ . '/services.yml';
+
 // Override paths for config files in Platform.sh.
 // Define a config sync directory outside the document root.
 if (isset($_ENV['PLATFORM_APP_DIR'])) {
   $config_directories[CONFIG_SYNC_DIRECTORY] = $_ENV['PLATFORM_APP_DIR'] . '/config/sync';
 }
+
 // Set trusted hosts based on real Platform.sh routes.
 if (isset($_ENV['PLATFORM_ROUTES'])) {
   $routes = json_decode(base64_decode($_ENV['PLATFORM_ROUTES']), TRUE);
@@ -84,8 +88,10 @@ if (getenv("PLATFORM_RELATIONSHIPS")) {
   ini_set('pcre.backtrack_limit', 200000);
   ini_set('pcre.recursion_limit', 200000);
 }
+
 // Force Drupal not to check for HTTP connectivity until we fixed the self test.
 $conf['drupal_http_request_fails'] = FALSE;
+
 // Local settings. These allow local development environments to use their own
 // database connections rather than the Platform-only settings above.
 if (file_exists(__DIR__ . '/settings.local.php')) {


### PR DESCRIPTION
- [x] Add the 2 missing files: `services.yaml` & `settings.php` required by Platform.sh (read-only filesystem). See [example here](https://github.com/platformsh/platformsh-example-drupal/tree/8.x-composer/web/sites/default).
