### PR TITLE
Remove Drush

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,12 +27,12 @@ script:
   - if [[ $RELEASE = dev ]]; then composer --verbose require --no-update drupal/core:8.0.x-dev; fi;
   - if [[ $RELEASE = dev ]]; then composer --verbose update; fi;
   - cd $TRAVIS_BUILD_DIR/web
-  - ./../vendor/bin/drush site-install --verbose --yes --db-url=sqlite://tmp/site.sqlite
-  - ./../vendor/bin/drush runserver http://127.0.0.1:8080 &
+  - ./../vendor/bin/drupal --version
+  - ./../vendor/bin/drupal init
+  - ./../vendor/bin/drupal site:install --db-type=sqlite --db-file=sites/default/files/.ht.sqlite --no-interaction
+  - ./../vendor/bin/drupal server 127.0.0.1:8080 &
   - sleep 3
   # Skip core/tests/Drupal/Tests/ComposerIntegrationTest.php because web/ has no composer.json
   - ./../vendor/bin/phpunit -c core --exclude-group Composer
-  - ./../vendor/bin/drush --version
-  - ./../vendor/bin/drupal --version
   # Exit if the install profile didn't default.
-  - ./../vendor/bin/drush status || grep -q "commerce_base" || exit 1;
+  - ./../vendor/bin/drupal site:status || grep -q "commerce_base" || exit 1;

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,6 @@
         "drupal-composer/drupal-scaffold": "~1",
         "cweagans/composer-patches": "~1.0",
         "drupal/core": "8.0.*",
-        "drush/drush": "~8.0",
         "drupal/console": "~0.10",
         "drupal/address": "8.1.x-dev",
         "drupal/entity": "8.1.x-dev",
@@ -57,8 +56,7 @@
             "web/core": ["type:drupal-core"],
             "web/modules/contrib/{$name}": ["type:drupal-module"],
             "web/profiles/contrib/{$name}": ["type:drupal-profile"],
-            "web/themes/contrib/{$name}": ["type:drupal-theme"],
-            "drush/contrib/{$name}": ["type:drupal-drush"]
+            "web/themes/contrib/{$name}": ["type:drupal-theme"]
         }
     }
 }

--- a/drush/README.md
+++ b/drush/README.md
@@ -1,1 +1,0 @@
-This directory contains commands, configuration and site aliases for Drush. See http://packages.drush.org/ for a directory of Drush commands installable via Composer.


### PR DESCRIPTION
Issue #2, remove Drush. Our docs promote Console and most users have
Drush globally via the phar, or Composer.
