### PR TITLE
Require drupal/core:~8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "drupal-composer/drupal-scaffold": "^2.2",
         "drupal/admin_toolbar": "~1.0",
         "drupal/console": "~1.0",
-        "drupal/core": "~8.3.0",
+        "drupal/core": "~8.4",
         "drupal/commerce": "~2.0",
         "drupal/search_api": "~1.0",
         "drupal/swiftmailer": "~1.0",


### PR DESCRIPTION
[The Commerce now requires 8.4 version of the core](https://github.com/drupalcommerce/commerce/blob/8.x-2.x/composer.json#L8).

Would it be sensible to do the same for the project-base?