### PR TITLE
Upgrade webflo/drupal-finder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "drupal/swiftmailer": "~1.0",
         "drupal/token": "~1.0",
         "drupalcommerce/commerce_base": "dev-8.x-1.x",
-        "webflo/drupal-finder": "^0.3.0",
+        "webflo/drupal-finder": "^1.0",
         "webmozart/path-util": "^2.3"
     },
     "require-dev": {


### PR DESCRIPTION
Both `drupal/console` and `drush/drush` require `webflo/drupal-finder:^1.0` for their new releases. 

We must update version constraint in project's composer.json to allow people creating new commerce projects to:
- install drush 9
- upgrade drupal console to newest release 