### PR TITLE
Makes the core and dev requirements more semantic

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "drupal-composer/drupal-scaffold": "^2.2",
         "drupal/admin_toolbar": "~1.0",
         "drupal/console": "~1.0",
-        "drupal/core": "~8.5",
+        "drupal/core": "~8.5.0",
         "drupal/commerce": "~2.0",
         "drupal/search_api": "~1.0",
         "drupal/swiftmailer": "~1.0",
@@ -45,7 +45,7 @@
         "webmozart/path-util": "^2.3"
     },
     "require-dev": {
-        "webflo/drupal-core-require-dev": "~8.4"
+        "webflo/drupal-core-require-dev": "~8.5.0"
     },
     "conflict": {
         "drupal/drupal": "*"


### PR DESCRIPTION
In composer, specifying ~8.5 will actually match 8.x.x greater than 8.5, if the intention is to match 8.5.x and prevent matching 8.6 when an update is available, the correct way of doing it is setting ~8.5.0 to match 8.5.x greater than 8.5.0 wich is the current 8 version.  Same applies to the webflo/drupal-core-require-dev