### PR TITLE
Add drush/drush as a dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
         "drupal/console": "~1.0",
         "drupal/core": "~8.5",
         "drupal/commerce": "~2.0",
+        "drush/drush": "^9.0.0",
         "drupal/search_api": "~1.0",
         "drupal/swiftmailer": "~1.0",
         "drupal/token": "~1.0",


### PR DESCRIPTION
Was testing this with drupalvm and got ```TASK [geerlingguy.drupal : Install Drupal with drush.] *************************
fatal: [commercevm]: FAILED! => {"changed": true, "cmd": ["drush", "site-install", "commerce_base", "-y", "--root=/var/www/drupalvm/drupal/web", "--site-name=Drupal", "--account-name=admin", "--account-pass=admin", "--db-url=mysql://drupal:drupal@localhost/drupal"], "delta": "0:00:00.025883", "end": "2018-04-23 20:30:21.964442", "msg": "non-zero return code", "rc": 1, "start": "2018-04-23 20:30:21.938559", "stderr": "", "stderr_lines": [], "stdout": "The Drush launcher could not find a local Drush in your Drupal site.\nPlease add Drush with Composer to your project.\nRun 'cd \"/var/www/drupalvm/drupal\" && composer require drush/drush'", "stdout_lines": ["The Drush launcher could not find a local Drush in your Drupal site.", "Please add Drush with Composer to your project.", "Run 'cd \"/var/www/drupalvm/drupal\" && composer require drush/drush'"]}``` I think we should add `drush/drush` as project dependency.