### PR TITLE
Drupal core has jQuery so tell Composer that for asset-packagist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,6 +72,10 @@
             "DrupalProject\\composer\\ScriptHandler::createRequiredFiles"
         ]
     },
+    "replace": {
+        "bower-asset/jquery": "3.2.1",
+        "npm-asset/jquery": "3.2.1"
+    },
     "extra": {
         "patchLevel": {
             "drupal/core": "-p2"


### PR DESCRIPTION
Otherwise, a lot of npm-asset/* and bower-asset/* packages also download an extra copy of jQuery into the libraries folder.